### PR TITLE
Add configurable web Mastermind game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mastermind Game</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Mastermind</h1>
+  </header>
+  <main>
+    <section id="config-section">
+      <form id="configForm">
+        <label>
+          Number of Pegs
+          <input type="number" id="numPegs" min="1" max="20" required />
+        </label>
+        <label>
+          Number of Colors
+          <input type="number" id="numColors" min="2" max="20" required />
+        </label>
+        <label>
+          <input type="checkbox" id="allowDuplicates" /> Allow Duplicates
+        </label>
+        <label>
+          Max Guesses
+          <input type="number" id="maxGuesses" min="1" value="10" required />
+        </label>
+        <button type="submit">Start Game</button>
+      </form>
+    </section>
+
+    <section id="game-section" class="hidden">
+      <div id="palette" class="palette"></div>
+      <div id="board" class="board"></div>
+      <div id="message" class="message"></div>
+      <button id="newGame">New Game</button>
+    </section>
+  </main>
+  <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,270 @@
+// Mastermind game logic
+
+const configSection = document.getElementById('config-section');
+const gameSection = document.getElementById('game-section');
+const configForm = document.getElementById('configForm');
+const paletteDiv = document.getElementById('palette');
+const boardDiv = document.getElementById('board');
+const messageDiv = document.getElementById('message');
+const newGameBtn = document.getElementById('newGame');
+
+let config = {};
+let secret = [];
+let paletteColors = [];
+let currentRow = 0;
+let colorPicker = null;
+
+// Handle configuration form submission
+configForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const numPegs = parseInt(document.getElementById('numPegs').value, 10);
+  const numColors = parseInt(document.getElementById('numColors').value, 10);
+  const allowDuplicates = document.getElementById('allowDuplicates').checked;
+  const maxGuesses = parseInt(document.getElementById('maxGuesses').value, 10) || 10;
+
+  if (numPegs < 1 || numPegs > 20 || numColors < 2 || numColors > 20 || maxGuesses < 1) {
+    alert('Please enter valid configuration values.');
+    return;
+  }
+  if (!allowDuplicates && numColors < numPegs) {
+    alert('Number of colors must be at least number of pegs when duplicates are disallowed.');
+    return;
+  }
+
+  config = { numPegs, numColors, allowDuplicates, maxGuesses };
+  startGame();
+});
+
+// Reset to configuration
+newGameBtn.addEventListener('click', () => {
+  boardDiv.innerHTML = '';
+  paletteDiv.innerHTML = '';
+  messageDiv.textContent = '';
+  gameSection.classList.add('hidden');
+  configSection.classList.remove('hidden');
+});
+
+// Initialize a new game
+function startGame() {
+  paletteColors = generatePalette(config.numColors);
+  renderPalette(paletteColors);
+  secret = generateSecret();
+  renderBoard();
+  currentRow = 0;
+  gameSection.classList.remove('hidden');
+  configSection.classList.add('hidden');
+}
+
+// Generate visual palette
+function renderPalette(colors) {
+  paletteDiv.innerHTML = '';
+  colors.forEach((color, idx) => {
+    const sw = document.createElement('div');
+    sw.className = 'color';
+    sw.style.background = color;
+    sw.title = idx;
+    paletteDiv.appendChild(sw);
+  });
+}
+
+// Create the guess board
+function renderBoard() {
+  boardDiv.innerHTML = '';
+  for (let r = 0; r < config.maxGuesses; r++) {
+    const row = document.createElement('div');
+    row.className = 'row';
+    row.dataset.row = r;
+
+    for (let c = 0; c < config.numPegs; c++) {
+      const peg = document.createElement('div');
+      peg.className = 'peg';
+      peg.dataset.index = c;
+      peg.addEventListener('click', handlePegClick);
+      if (r !== 0) peg.style.pointerEvents = 'none';
+      row.appendChild(peg);
+    }
+
+    const feedback = document.createElement('div');
+    feedback.className = 'feedback';
+    row.appendChild(feedback);
+
+    const submit = document.createElement('button');
+    submit.textContent = 'Submit Guess';
+    submit.disabled = true;
+    submit.addEventListener('click', submitGuess);
+    if (r !== 0) submit.disabled = true;
+    row.appendChild(submit);
+
+    boardDiv.appendChild(row);
+  }
+}
+
+// Handle peg click to open color picker
+function handlePegClick(e) {
+  const peg = e.currentTarget;
+  const rowIndex = parseInt(peg.parentElement.dataset.row, 10);
+  if (rowIndex !== currentRow) return;
+
+  removeColorPicker();
+  colorPicker = document.createElement('div');
+  colorPicker.className = 'color-picker';
+  paletteColors.forEach((color, idx) => {
+    const sw = document.createElement('div');
+    sw.className = 'color';
+    sw.style.background = color;
+    sw.dataset.color = idx;
+    sw.addEventListener('click', () => {
+      peg.style.background = color;
+      peg.dataset.color = idx;
+      removeColorPicker();
+      checkRowFilled(rowIndex);
+    });
+    colorPicker.appendChild(sw);
+  });
+  document.body.appendChild(colorPicker);
+  const rect = peg.getBoundingClientRect();
+  colorPicker.style.left = `${rect.left + window.scrollX}px`;
+  colorPicker.style.top = `${rect.bottom + window.scrollY}px`;
+}
+
+function removeColorPicker() {
+  if (colorPicker) {
+    colorPicker.remove();
+    colorPicker = null;
+  }
+}
+
+document.addEventListener('click', e => {
+  if (colorPicker && !colorPicker.contains(e.target) && !e.target.classList.contains('peg')) {
+    removeColorPicker();
+  }
+});
+
+// Enable submit when row filled
+function checkRowFilled(rowIndex) {
+  const row = boardDiv.querySelector(`.row[data-row="${rowIndex}"]`);
+  const pegs = Array.from(row.querySelectorAll('.peg'));
+  const filled = pegs.every(p => p.dataset.color !== undefined);
+  const btn = row.querySelector('button');
+  btn.disabled = !filled;
+}
+
+// Submit a guess and compute feedback
+function submitGuess(e) {
+  const row = e.currentTarget.parentElement;
+  const rowIndex = parseInt(row.dataset.row, 10);
+  const guess = Array.from(row.querySelectorAll('.peg')).map(p => parseInt(p.dataset.color, 10));
+
+  const { black, white } = calculateFeedback(guess, secret);
+  const feedback = row.querySelector('.feedback');
+  for (let i = 0; i < black; i++) feedback.appendChild(createMark('black'));
+  for (let i = 0; i < white; i++) feedback.appendChild(createMark('white'));
+
+  row.querySelectorAll('.peg').forEach(p => (p.style.pointerEvents = 'none'));
+  e.currentTarget.disabled = true;
+
+  if (black === config.numPegs) {
+    messageDiv.textContent = 'You Win!';
+    revealSecret();
+    endGame();
+    return;
+  }
+
+  if (rowIndex + 1 >= config.maxGuesses) {
+    messageDiv.textContent = 'Game Over';
+    revealSecret();
+    endGame();
+    return;
+  }
+
+  currentRow++;
+  enableRow(currentRow);
+}
+
+// Enable next row for input
+function enableRow(index) {
+  const row = boardDiv.querySelector(`.row[data-row="${index}"]`);
+  row.querySelectorAll('.peg').forEach(p => (p.style.pointerEvents = 'auto'));
+  row.querySelector('button').disabled = true;
+}
+
+// Reveal the secret code
+function revealSecret() {
+  const secretDiv = document.createElement('div');
+  secretDiv.className = 'secret';
+  secret.forEach(idx => {
+    const peg = document.createElement('div');
+    peg.className = 'peg';
+    peg.style.background = paletteColors[idx];
+    secretDiv.appendChild(peg);
+  });
+  messageDiv.appendChild(secretDiv);
+}
+
+// Stop all remaining input
+function endGame() {
+  boardDiv.querySelectorAll('.row').forEach(r => {
+    r.querySelectorAll('.peg').forEach(p => (p.style.pointerEvents = 'none'));
+    r.querySelector('button').disabled = true;
+  });
+  removeColorPicker();
+}
+
+// Create feedback mark
+function createMark(type) {
+  const m = document.createElement('div');
+  m.className = `mark ${type}`;
+  return m;
+}
+
+// Generate the secret code
+function generateSecret() {
+  const colors = [...Array(config.numColors).keys()];
+  const result = [];
+  if (config.allowDuplicates) {
+    for (let i = 0; i < config.numPegs; i++) {
+      const idx = Math.floor(Math.random() * colors.length);
+      result.push(colors[idx]);
+    }
+  } else {
+    const pool = [...colors];
+    for (let i = 0; i < config.numPegs; i++) {
+      const r = Math.floor(Math.random() * pool.length);
+      result.push(pool.splice(r, 1)[0]);
+    }
+  }
+  return result;
+}
+
+// Calculate feedback for a guess
+function calculateFeedback(guess, secret) {
+  let black = 0;
+  const secretCounts = {};
+  const guessCounts = {};
+
+  for (let i = 0; i < secret.length; i++) {
+    if (guess[i] === secret[i]) {
+      black++;
+    } else {
+      secretCounts[secret[i]] = (secretCounts[secret[i]] || 0) + 1;
+      guessCounts[guess[i]] = (guessCounts[guess[i]] || 0) + 1;
+    }
+  }
+
+  let white = 0;
+  Object.keys(guessCounts).forEach(color => {
+    white += Math.min(guessCounts[color] || 0, secretCounts[color] || 0);
+  });
+
+  return { black, white };
+}
+
+// Generate color palette strings
+function generatePalette(numColors) {
+  const arr = [];
+  for (let i = 0; i < numColors; i++) {
+    const hue = Math.floor((360 / numColors) * i);
+    arr.push(`hsl(${hue}, 70%, 50%)`);
+  }
+  return arr;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,93 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+header {
+  background: #333;
+  color: white;
+  padding: 1rem;
+  text-align: center;
+}
+main {
+  flex: 1;
+  padding: 1rem;
+}
+.hidden {
+  display: none;
+}
+#configForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 300px;
+}
+.palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.palette .color {
+  width: 24px;
+  height: 24px;
+  border: 1px solid #333;
+  cursor: pointer;
+}
+.board {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.row .peg {
+  width: 30px;
+  height: 30px;
+  border: 1px solid #999;
+  cursor: pointer;
+}
+.feedback {
+  display: flex;
+  gap: 4px;
+  margin-left: 0.5rem;
+}
+.feedback .mark {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid #333;
+}
+.feedback .black {
+  background: black;
+}
+.feedback .white {
+  background: white;
+}
+.message {
+  margin-top: 1rem;
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+.color-picker {
+  position: absolute;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  background: #fff;
+  border: 1px solid #333;
+  padding: 4px;
+  z-index: 10;
+}
+.color-picker .color {
+  width: 20px;
+  height: 20px;
+  border: 1px solid #333;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Implement configurable Mastermind game with dynamic color palette, board, and feedback
- Add styling for board, color picker, and responsive layout
- Include secret code generation and feedback logic in vanilla JS

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891547d40f48331bf770033429f3dd0