### PR TITLE
Add modular game logic and unit tests

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -1,0 +1,48 @@
+export function generatePalette(numColors) {
+  const arr = [];
+  for (let i = 0; i < numColors; i++) {
+    const hue = Math.floor((360 / numColors) * i);
+    arr.push(`hsl(${hue}, 70%, 50%)`);
+  }
+  return arr;
+}
+
+export function generateSecret(config) {
+  const colors = [...Array(config.numColors).keys()];
+  const result = [];
+  if (config.allowDuplicates) {
+    for (let i = 0; i < config.numPegs; i++) {
+      const idx = Math.floor(Math.random() * colors.length);
+      result.push(colors[idx]);
+    }
+  } else {
+    const pool = [...colors];
+    for (let i = 0; i < config.numPegs; i++) {
+      const r = Math.floor(Math.random() * pool.length);
+      result.push(pool.splice(r, 1)[0]);
+    }
+  }
+  return result;
+}
+
+export function calculateFeedback(guess, secret) {
+  let black = 0;
+  const secretCounts = {};
+  const guessCounts = {};
+
+  for (let i = 0; i < secret.length; i++) {
+    if (guess[i] === secret[i]) {
+      black++;
+    } else {
+      secretCounts[secret[i]] = (secretCounts[secret[i]] || 0) + 1;
+      guessCounts[guess[i]] = (guessCounts[guess[i]] || 0) + 1;
+    }
+  }
+
+  let white = 0;
+  Object.keys(guessCounts).forEach(color => {
+    white += Math.min(guessCounts[color] || 0, secretCounts[color] || 0);
+  });
+
+  return { black, white };
+}

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,5 @@
 // Mastermind game logic
+import { generatePalette, generateSecret, calculateFeedback } from './logic.js';
 
 const configSection = document.getElementById('config-section');
 const gameSection = document.getElementById('game-section');
@@ -48,7 +49,7 @@ newGameBtn.addEventListener('click', () => {
 function startGame() {
   paletteColors = generatePalette(config.numColors);
   renderPalette(paletteColors);
-  secret = generateSecret();
+  secret = generateSecret(config);
   renderBoard();
   currentRow = 0;
   gameSection.classList.remove('hidden');
@@ -215,56 +216,4 @@ function createMark(type) {
   const m = document.createElement('div');
   m.className = `mark ${type}`;
   return m;
-}
-
-// Generate the secret code
-function generateSecret() {
-  const colors = [...Array(config.numColors).keys()];
-  const result = [];
-  if (config.allowDuplicates) {
-    for (let i = 0; i < config.numPegs; i++) {
-      const idx = Math.floor(Math.random() * colors.length);
-      result.push(colors[idx]);
-    }
-  } else {
-    const pool = [...colors];
-    for (let i = 0; i < config.numPegs; i++) {
-      const r = Math.floor(Math.random() * pool.length);
-      result.push(pool.splice(r, 1)[0]);
-    }
-  }
-  return result;
-}
-
-// Calculate feedback for a guess
-function calculateFeedback(guess, secret) {
-  let black = 0;
-  const secretCounts = {};
-  const guessCounts = {};
-
-  for (let i = 0; i < secret.length; i++) {
-    if (guess[i] === secret[i]) {
-      black++;
-    } else {
-      secretCounts[secret[i]] = (secretCounts[secret[i]] || 0) + 1;
-      guessCounts[guess[i]] = (guessCounts[guess[i]] || 0) + 1;
-    }
-  }
-
-  let white = 0;
-  Object.keys(guessCounts).forEach(color => {
-    white += Math.min(guessCounts[color] || 0, secretCounts[color] || 0);
-  });
-
-  return { black, white };
-}
-
-// Generate color palette strings
-function generatePalette(numColors) {
-  const arr = [];
-  for (let i = 0; i < numColors; i++) {
-    const hue = Math.floor((360 / numColors) * i);
-    arr.push(`hsl(${hue}, 70%, 50%)`);
-  }
-  return arr;
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "color-guesser",
   "version": "1.0.0",
   "description": "Configurable Mastermind-style color guessing game",
+  "type": "module",
   "scripts": {
     "start": "npx http-server . -c-1",
-    "test": "echo \"No tests specified\""
+    "test": "node --test"
   },
   "license": "MIT"
 }

--- a/test/logic.test.js
+++ b/test/logic.test.js
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { generatePalette, generateSecret, calculateFeedback } from '../js/logic.js';
+
+describe('generatePalette', () => {
+  it('creates distinct hsl colors', () => {
+    const palette = generatePalette(5);
+    assert.equal(palette.length, 5);
+    palette.forEach(color => {
+      assert.match(color, /^hsl\(/);
+    });
+  });
+});
+
+describe('generateSecret', () => {
+  it('allows duplicates when configured', () => {
+    const config = { numColors: 4, numPegs: 4, allowDuplicates: true };
+    const originalRandom = Math.random;
+    const seq = [0.1, 0.1, 0.4, 0.4];
+    Math.random = () => seq.shift();
+    const secret = generateSecret(config);
+    Math.random = originalRandom;
+    assert.deepEqual(secret, [0, 0, 1, 1]);
+  });
+
+  it('prevents duplicates when disallowed', () => {
+    const config = { numColors: 4, numPegs: 4, allowDuplicates: false };
+    const originalRandom = Math.random;
+    const seq = [0.1, 0.1, 0.1, 0.1];
+    Math.random = () => seq.shift();
+    const secret = generateSecret(config);
+    Math.random = originalRandom;
+    // Should contain all unique values
+    assert.deepEqual(new Set(secret).size, secret.length);
+  });
+});
+
+describe('calculateFeedback', () => {
+  it('returns all black for exact match', () => {
+    const secret = [1, 2, 3, 4];
+    const guess = [1, 2, 3, 4];
+    const result = calculateFeedback(guess, secret);
+    assert.deepEqual(result, { black: 4, white: 0 });
+  });
+
+  it('handles all colors correct but misplaced', () => {
+    const secret = [1, 2, 3, 4];
+    const guess = [4, 3, 2, 1];
+    const result = calculateFeedback(guess, secret);
+    assert.deepEqual(result, { black: 0, white: 4 });
+  });
+
+  it('handles mixed black and white pegs', () => {
+    const secret = [1, 1, 2, 2];
+    const guess = [1, 2, 1, 2];
+    const result = calculateFeedback(guess, secret);
+    assert.deepEqual(result, { black: 2, white: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- move core Mastermind logic into its own ES module
- enable Node's test runner and add tests for palette generation, secret creation, and feedback calculation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891591cd5c883319ff9b386e503b813